### PR TITLE
ci(qualify): assert forjar, never install it over the fleet's toolchain

### DIFF
--- a/.github/workflows/qualify-runner.yml
+++ b/.github/workflows/qualify-runner.yml
@@ -14,8 +14,39 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install forjar (latest from source)
-        run: cargo install --path ../forjar --locked
+      # ASSERT the toolchain; do not install it.
+      #
+      # This was `cargo install --path ../forjar --locked`, which is wrong three
+      # times over on a self-hosted runner:
+      #
+      #   1. `../forjar` is OUTSIDE $GITHUB_WORKSPACE. Hardened checkout does not
+      #      place sibling repos there, so the path resolves to nothing — which
+      #      is why all 6 runs of this workflow have FAILED (last: 2026-03-10).
+      #   2. With no `--root`, it installs into the shared ~/.cargo/bin. All 16
+      #      intel-clean-room runners share HOME=/home/noah, so that directory is
+      #      the FLEET'S PROVISIONED TOOLCHAIN. Had this step ever worked, it
+      #      would have replaced the fleet's pinned forjar with whatever happened
+      #      to be in a sibling checkout — silently making the version pin in
+      #      machines/*/forjar.yaml fiction.
+      #   3. It triggers on `push` to recipes/** and configs/**, so ordinary
+      #      content edits would have carried it.
+      #
+      # forjar is provisioned on these hosts by forjar itself, pinned in
+      # paiml/infra machines/*/forjar.yaml. A consumer asserts it is there. This
+      # is the same rule the fleet's pre-job hook states: "This hook asserts the
+      # toolchain; it no longer installs it."
+      #
+      # `--version` rather than `command -v`: the latter is satisfied by a
+      # dangling symlink, which is exactly the state a CI cache-prune leaves in a
+      # shared ~/.cargo/bin (paiml/infra#208).
+      - name: Assert forjar is provisioned on this runner
+        run: |
+          forjar --version || {
+            echo "FATAL: forjar is not provisioned on this runner." >&2
+            echo "  Remediate on the host, not per job:" >&2
+            echo "    forjar apply -f machines/intel/forjar.yaml -t stack-tools --refresh" >&2
+            exit 1
+          }
 
       - name: Qualify recipes
         run: |


### PR DESCRIPTION
## What

Replaces `cargo install --path ../forjar --locked` with an assertion that forjar is present.

## Why

That step runs on `runs-on: self-hosted` and is wrong three times over:

**1. It cannot work.** `../forjar` is outside `$GITHUB_WORKSPACE`; hardened checkout does not place sibling repos there. **All 6 runs of this workflow have failed**, most recently 2026-03-10. It has never once done what its name says.

**2. If it ever did work, it would break the fleet.** With no `--root`, `cargo install` writes to the shared `~/.cargo/bin`. All 16 `intel-clean-room-*` runners share `HOME=/home/noah`, so that directory *is* the fleet's provisioned toolchain. This step would replace the fleet's pinned `forjar` with whatever happened to be in a sibling checkout — silently making the `version:` pin in `paiml/infra` `machines/*/forjar.yaml` fiction.

**3. Its trigger is too broad.** `push` to `recipes/**` and `configs/**`, so ordinary content edits carry it.

## The rule

forjar is provisioned on these hosts *by forjar*, pinned. A consumer asserts it's there. Same rule the fleet's pre-job hook already states: *"This hook asserts the toolchain; it no longer installs it."*

`--version` rather than `command -v`, because `command -v` is satisfied by a dangling symlink — precisely the state a CI cache-prune leaves in a shared `~/.cargo/bin` (paiml/infra#208).

## Context

Found while auditing every self-hosted job across the fleet after intel's toolchain was destroyed on 2026-08-19. This one is currently inert (it fails before doing damage), but a job that always fails is its own problem — it trains people to ignore a red check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)